### PR TITLE
Set print target with css class

### DIFF
--- a/printomat.js
+++ b/printomat.js
@@ -29,6 +29,14 @@ jQuery(document).ready(function() {
 		var id = jQuery(this).attr('id');
 		var target = jQuery(this).data('print_target');
 		if(!target){
+			classes = jQuery(this).attr("class").split(/\s+/);
+			for(i=0; i<classes.length; i++){
+				if(classes[i].substring(0, 12) == "printtarget-"){
+					target = classes[i].substring(12, classes[i].length)
+				}
+			}
+		}
+		if(!target){
 			target = jQuery('#target-' + id).val();
 		}
 		if (target == '%prev%') {


### PR DESCRIPTION
You can use every element as a print o matic print trigger by adding .printomatic class and .printtarget-<target> class. This is helpfull if it is not possible to add a custom data tag (data-print_target) to elements, for example in visual builders.