### PR TITLE
Increase version number

### DIFF
--- a/print-o-matic.php
+++ b/print-o-matic.php
@@ -4,7 +4,7 @@ Plugin Name: Print-O-Matic
 Text Domain: print-o-matic
 Plugin URI: https://pluginoven.com/plugins/print-o-matic/
 Description: Shortcode that adds a printer icon, allowing the user to print the post or a specified HTML element in the post.
-Version: 2.1.10
+Version: 2.1.11
 Author: twinpictures
 Author URI: https://twinpictures.de
 License: GPL2
@@ -17,7 +17,7 @@ License: GPL2
  */
 class WP_Print_O_Matic {
 
-	var $version = '2.1.10';
+	var $version = '2.1.11';
 	var $domain = 'printomat';
 	var $options_name = 'WP_Print_O_Matic_options';
 	var $options = array(


### PR DESCRIPTION
Increase version number to avoid security warning of Jetpack/WPScan. CVE-2024-33936 has been fixed by commit d24bf4fd4cda37909f68d05c53d929aa1dea25e5, but the version number has not been increased. See https://wpscan.com/vulnerability/42a0770a-3d3e-4ff0-be15-bba6a1a72341/